### PR TITLE
Fix Nexus Channels being visible for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ The purpose of this bot is to create text channel, which is visible only to thos
 Each time the last user leaves the voice channel, all non-pinned messages in linked text channel will be deleted. 
 
 ## Want to use at your server?
-[![Discord Bots](https://top.gg/api/widget/709876107213537351.svg)](https://top.gg/bot/709876107213537351)  
-You can use the bot via this [link](https://discord.com/oauth2/authorize?client_id=709876107213537351&permissions=268510224&scope=bot).
+[![Invite bot to your server](https://i.imgur.com/MgQZMpT.jpg)](https://discord.com/oauth2/authorize?client_id=709876107213537351&permissions=268510224&scope=bot)
 
 ## How to use
 You don't need to set up anything - once you join a voice channel, a new category with the linked text channel will be created.  
@@ -27,6 +26,12 @@ If you have any issue with the bot functionality, feel free to post an issue in 
 ### Need any adjustments?
 If you feel some cool feature is missing, or you want to make some minor tweaks just for your quality of life - feel free to either post an issue in the repo or make a fork and adjust it yourself as you see fit.  
 Please bear in mind: I intend to leave this bot single-purpose, meaning I won't add features which are not related to the idea of creating combined voice-text channels.
+
+## If you like the bot
+Nexus bot was approved by the top.gg administrators (one of the biggest aggregator for the Discord bots and servers)
+If you feel the bot is worthy enough - you can vote for it at [its top.gg page](https://top.gg/bot/709876107213537351).
+You can do it every 12 hours. If you also want your server to be mentioned as one of the communities this bot empowers - make an issue [here](https://github.com/andretkachenko/nexus-bot/issues/new/choose) (only possible if you add the server to the top.gg).
+Voting isn't required, but always appreciated) I will be glad to know that my work helps people achieve what they want.
 
 ## Environment setup
 1. Install NodeJS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-bot",
-  "version": "2.2.2",
+  "version": "2.2.10",
   "description": "discord bot to map text channel to each voice channel",
   "main": "build/main.js",
   "author": "andretkachenko",

--- a/src/handlers/ChannelOperator.ts
+++ b/src/handlers/ChannelOperator.ts
@@ -8,7 +8,7 @@ import { TextCategoryMap } from "../entities/TextCategoryMap";
 import { Permission } from "../enums/Permission";
 
 export class ChannelOperator {
-    private client: Client
+	private client: Client
 	private mongoConnector: MongoConnector
 	private config: Config
 	private logger: Logger
@@ -56,27 +56,25 @@ export class ChannelOperator {
 	}
 
 	private async createTextChannel(newVoiceState: VoiceState) {
-		let guild = newVoiceState.channel?.guild	
+		let guild = newVoiceState.channel?.guild
 
 		if (guild && guild.me?.permissions.has(Permission.MANAGE_CHANNELS) && guild.me?.permissions.has(Permission.MANAGE_ROLES)) {
 			let user = newVoiceState.member
 			let voiceChannel = newVoiceState.channel
-			let channelId = newVoiceState.channelID as string	
+			let channelId = newVoiceState.channelID as string
 			let parentId = await this.resolveTextCategory(guild)
 			let options: GuildCreateChannelOptions = {
-				permissionOverwrites: [{ id: guild.id, deny: [Permission.VIEW_CHANNEL] }, {id: this.client.user ? this.client.user.id : "", allow: [Permission.VIEW_CHANNEL] }],
+				permissionOverwrites: [
+					{ id: guild.id, deny: [Permission.VIEW_CHANNEL] },
+					{ id: this.client.user ? this.client.user.id : "", allow: [Permission.VIEW_CHANNEL] },
+					{ id: user ? user.id : "undefined", allow: [Permission.VIEW_CHANNEL] }
+				],
 				type: ChannelType.text,
 			}
 			if (parentId) options.parent = parentId as string
 			if (voiceChannel) {
 				newVoiceState.channel?.guild.channels.create(voiceChannel.name + '-text', options)
 					.then(ch => {
-						ch.overwritePermissions([
-							{
-								id: user ? user.id : "undefined",
-								allow: [Permission.VIEW_CHANNEL],
-							},
-						]);
 						let textChannelMap: TextChannelMap = { guildId: ch.guild.id, voiceChannelId: channelId, textChannelId: ch.id }
 						this.mongoConnector.textChannelRepository.add(textChannelMap)
 					});
@@ -89,7 +87,7 @@ export class ChannelOperator {
 	}
 
 	private showHideTextChannel(textChannel: TextChannel, user: GuildMember | null, value: boolean) {
-		if(!textChannel.guild.me?.permissions.has(Permission.MANAGE_CHANNELS)) return
+		if (!textChannel.guild.me?.permissions.has(Permission.MANAGE_CHANNELS)) return
 
 		if (user && textChannel) {
 			if (user.hasPermission(Permission.ADMINISTRATOR) || user.user.bot) return
@@ -98,7 +96,7 @@ export class ChannelOperator {
 	}
 
 	private async deleteNotPinnedMessages(textChannel: TextChannel) {
-		if(!textChannel.guild.me?.permissions.has(Permission.MANAGE_MESSAGES)) return
+		if (!textChannel.guild.me?.permissions.has(Permission.MANAGE_MESSAGES)) return
 
 		let fetched: Collection<string, Message>;
 		let notPinned: Collection<string, Message>;
@@ -119,7 +117,7 @@ export class ChannelOperator {
 	}
 
 	private async createCategory(guild: Guild): Promise<string> {
-		if(!guild.me?.permissions.has(Permission.MANAGE_CHANNELS)) return ''
+		if (!guild.me?.permissions.has(Permission.MANAGE_CHANNELS)) return ''
 
 		let channelCreationPromise = guild.channels.create(this.config.categoryName, {
 			type: ChannelType.category


### PR DESCRIPTION
# Description

When a new user joins server he could see all Nexus Channels as they didn't have proper permissions. Reworked permission overwrites creation process to avoid Discord API error at changing permissions right after channel creation.

Fixes #59 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Kick test user 1 from the test server
2. Remove Nexus Channels
3. Join voice channel 1 with test user 1
4. Go to voice channel 2 with test user 1
5. Check permissions on newly created Nexus Channels
6. Join test server by test user 1
7. Observe Nexus Channels (shouldn't be visible for test user 1 before he joins a voice channel)

**Test Configuration**:
* Firmware version: 0.0.307
* Hardware: Win 10
* Toolchain: VSCode, Discord, Google Chrome

# Checklist:
- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] I have made a pull request against the **develop branch** (left side). 
- [x] The branch was started off *develop branch*.
- [x] All commits' message styles match the requested structure.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
