### PR TITLE
delete channels and categories from db at bot kick

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-bot",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "discord bot to map text channel to each voice channel",
   "main": "build/main.js",
   "author": "andretkachenko",

--- a/src/db/TextChannelRepository.ts
+++ b/src/db/TextChannelRepository.ts
@@ -37,6 +37,21 @@ export class TextChannelRepository {
             })
     }
 
+    public async deleteAllGuildChannels(guildId: string): Promise<boolean> {
+        let result = false
+        let db = this.client.db(this.dbName)
+        let textChannels = db.collection(this.textChannelCollectionName)
+        return textChannels.deleteMany({ guildId: guildId })
+            .then((deleteResult) => {
+                if (deleteResult.result.ok !== 1) console.log("command not executed correctly: documents not deleted")
+                else {
+                    console.log("documents deleted")
+                    result = true
+                }
+                return result
+            })
+    }
+
     public async add(textChannelMap: TextChannelMap): Promise<boolean> {
         let result = false
         let db = this.client.db(this.dbName)

--- a/src/handlers/ServerHandlers.ts
+++ b/src/handlers/ServerHandlers.ts
@@ -1,0 +1,15 @@
+import { Guild } from "discord.js";
+import { MongoConnector } from "../db/MongoConnector";
+
+export class ServerHandlers {
+    private mongoConnector: MongoConnector
+
+    constructor(mongoConnector: MongoConnector) {
+        this.mongoConnector = mongoConnector
+    }
+
+    public async handleBotKickedFromServer(guild: Guild) {
+        this.mongoConnector.textCategoryRepository.delete(guild.id);
+        this.mongoConnector.textChannelRepository.deleteAllGuildChannels(guild.id);
+    }
+}


### PR DESCRIPTION
# Description

- Add a handler to remove category ID from MongoDB for a server when the bot is kicked from it;
- Add a handler to remove all channel IDs from MongoDB for a server when the bot is kicked from it.

Fixes #64 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Kick bot from a test server
2. Ensure category ID and channel IDs were removed for test server from DB
3. Ensure other server info on DB remains intact.
4. Add bot to a test server.
5. Jump through voice channels
6. Ensure new category and new channels were created on a test server.
7. Ensure category ID and channel IDs were stored in DB.

**Test Configuration**:
* Firmware version: 0.0.307
* Hardware: Win 10
* Toolchain: VSCode, Discord, Google Chrome

# Checklist:
- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] I have made a pull request against the **develop branch** (left side). 
- [x] The branch was started off *develop branch*.
- [x] All commits' message styles match the requested structure.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules