### PR TITLE
Stage Channels support workaround

### DIFF
--- a/src/db/IgnoredChannelsRepository.ts
+++ b/src/db/IgnoredChannelsRepository.ts
@@ -8,7 +8,7 @@ export class IgnoredChannelsRepository extends Repository<IgnoredChannel> {
 		super(logger, client, dbName)
 	}
 
-	public async exists(guildId: string, channelId: string): Promise<boolean> {
+	public async exists(guildId: string | undefined, channelId: string | undefined): Promise<boolean> {
 		return super.getFirst({ guildId, channelId })
 			.then(channel => {
 				return channel !== undefined && channel !== null


### PR DESCRIPTION

# Description

Currently, there's no proper way to implement stage channels support. 
DiscordJS team is currently working on it, but no ETA available.
This implementation allows adding relatively solid stage channels support - the only issue is that the linked text channel will get an 'undefined-text' name, which should be resolved as soon as DiscordJS will obtain proper stage channel support.

Fixes #118 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration  

1. Make test server a community
2. Create stage channel `stage1`
3. Join `stage1`
4. Ensure new text channel `undefined-text` was created under the `Nexus channels` category
5. Join `stage1` as a listener
6. Ensure the listener can view the `undefined-text` channel
<!-- -->
1. As listener, leave `stage1`
2. Ensure listener can no longer see the `undefined-text` channel

**Test Configuration**:
* Firmware version: 0.0.307
* Hardware: Win 10
* Toolchain: VSCode, Discord, Google Chrome

# Checklist:
- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] I have made a pull request against the **develop branch** (left side). 
- [x] The branch was started off *develop branch*.
- [x] All commits' message styles match the requested structure.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules