### PR TITLE
rework showHideTextChannel()

### DIFF
--- a/src/handlers/ChannelHandlers.ts
+++ b/src/handlers/ChannelHandlers.ts
@@ -24,7 +24,7 @@ import {
 } from '../enums'
 import { Constants } from '../descriptor'
 import { TypeGuarder } from '../services'
-import { Channels as AnyChannel, SafePermissionOverwriteOptions } from '../types'
+import { Channels as AnyChannel } from '../types'
 
 
 export class ChannelHandlers {
@@ -127,10 +127,17 @@ export class ChannelHandlers {
 
 		this.skip(user)
 			.then(skip => {
+				// if user configured to ignore standard visibility configuration - return
 				if (skip) return
+				// if user left the channel - remove his see-channel overwrite rule and return
+				if(!value) {
+					textChannel.permissionOverwrites.delete(user)
+						.catch(reason => this.logger.logError(this.constructor.name, this.showHideTextChannel.name, reason, textChannel.guild.id))
+					return
+				}
+				// if user joined channel - add see-channel overwrite rule and return
 				// eslint-disable-next-line @typescript-eslint/naming-convention
-				const option : SafePermissionOverwriteOptions = { VIEW_CHANNEL : value }
-				textChannel.permissionOverwrites.edit(user, option)
+				textChannel.permissionOverwrites.create(user, { VIEW_CHANNEL : value })
 					.catch(reason => this.logger.logError(this.constructor.name, this.showHideTextChannel.name, reason, textChannel.guild.id))
 			})
 			.catch(reason => this.logger.logError(this.constructor.name, this.showHideTextChannel.name, reason, textChannel.guild.id))


### PR DESCRIPTION
# Description

Rework the `showHideTextChannel` method to create/delete permission overwrites instead of always
editing to ensure that channel permissions won't be cluttered for
bigger servers

Fixes #159 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By jumping between channel back and forth while checking channel permissions and audit log.

# Checklist:
- [x] I am requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] I have made a pull request against the **develop branch** (left side). 
- [x] The branch was started off *develop branch*.
- [x] All commits' message styles match the requested structure.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
